### PR TITLE
Add submodule initialisation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ dependencies from Bash or Windows command line.
 
 ```bash
 cd path/to/sierra
+# initialize the hiv-genotyper submodule (first setup only)
+git submodule init && git submodule update
 # any gradle command will trigger downloading of dependencies
 ./gradlew assemble
 ```
@@ -83,6 +85,9 @@ cd path/to/sierra
 
 ```winbatch
 cd path\to\sierra
+# initialize the hiv-genotyper submodule (first setup only)
+git submodule init
+git submodule update
 gradlew.bat assemble
 ```
 


### PR DESCRIPTION
This commit adds instructions for initialising up the `hiv-genotyper`
submodule when setting up Sierra, which isn't currently mentioned. If
the existing instructions are followed naively, `gradle` will put
build files in the submodule directory , at which point git will resist
initialising it because it isn't empty.